### PR TITLE
fix: auto-refresh dashboard data on blockchain state changes

### DIFF
--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -38,6 +38,12 @@ const Dashboard = () => {
 
   useEffect(() => {
     fetchDashboardData();
+
+    const interval = setInterval(() => {
+      fetchDashboardData();
+    }, 30000);
+
+    return () => clearInterval(interval);
   }, [isConnected]);
 
   const fetchDashboardData = async () => {
@@ -80,7 +86,11 @@ const Dashboard = () => {
       <Typography variant="h4" gutterBottom fontWeight="bold">
         🚀 Stellar DID Platform Dashboard
       </Typography>
-      
+      <Box display="flex" justifyContent="flex-end" mb={2}>
+  <Button variant="outlined" onClick={fetchDashboardData} startIcon={<TrendingUp />}>
+    Refresh
+  </Button>
+</Box>
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}


### PR DESCRIPTION
## Problem
Dashboard only fetched data once on mount. No automatic updates 
when blockchain state changed.

## Solution
- Added 30-second polling interval to auto-refresh data
- Added manual Refresh button for on-demand updates
- Added cleanup function to prevent memory leaks on unmount

## Testing
Tested locally - dashboard loads, refresh button works, 
auto-polling confirmed every 30 seconds.

Closes #14