### PR TITLE
feat: improve database indexing strategy 

### DIFF
--- a/backend/src/migrations/002_add_indexes.js
+++ b/backend/src/migrations/002_add_indexes.js
@@ -1,0 +1,97 @@
+const mongoose = require('mongoose');
+
+/**
+ * Migration: 002_add_indexes
+ * Description: Add indexes to all collections to improve query performance.
+ *
+ * Indexes added:
+ *   credentials  - issuer+issued, subject+issued, credentialType+issued,
+ *                  revoked+issued, expires, issuer+credentialType+issued,
+ *                  subject+revoked
+ *   dids         - owner+created, owner+active, active+created
+ *   apikeys      - owner+status, expiresAt (sparse)
+ *   sessions     - userId+isValid
+ *   webhooks     - active, events+active
+ *   credentialtemplates - credentialType+active, issuerDid+active
+ */
+
+const INDEX_SPECS = {
+  credentials: [
+    { key: { issuer: 1, issued: -1 },           options: { name: 'issuer_issued' } },
+    { key: { subject: 1, issued: -1 },           options: { name: 'subject_issued' } },
+    { key: { credentialType: 1, issued: -1 },    options: { name: 'credentialType_issued' } },
+    { key: { revoked: 1, issued: -1 },           options: { name: 'revoked_issued' } },
+    { key: { expires: 1 },                       options: { name: 'expires' } },
+    { key: { issuer: 1, credentialType: 1, issued: -1 }, options: { name: 'issuer_credentialType_issued' } },
+    { key: { subject: 1, revoked: 1 },           options: { name: 'subject_revoked' } },
+  ],
+  dids: [
+    { key: { owner: 1, created: -1 },  options: { name: 'owner_created' } },
+    { key: { owner: 1, active: 1 },    options: { name: 'owner_active' } },
+    { key: { active: 1, created: -1 }, options: { name: 'active_created' } },
+  ],
+  apikeys: [
+    { key: { owner: 1, status: 1 },  options: { name: 'owner_status' } },
+    { key: { expiresAt: 1 },         options: { name: 'expiresAt', sparse: true } },
+  ],
+  sessions: [
+    { key: { userId: 1, isValid: 1 }, options: { name: 'userId_isValid' } },
+  ],
+  webhooks: [
+    { key: { active: 1 },          options: { name: 'active' } },
+    { key: { events: 1, active: 1 }, options: { name: 'events_active' } },
+  ],
+  credentialtemplates: [
+    { key: { credentialType: 1, active: 1 }, options: { name: 'credentialType_active' } },
+    { key: { issuerDid: 1, active: 1 },      options: { name: 'issuerDid_active' } },
+  ],
+};
+
+module.exports = {
+  up: async () => {
+    const db = mongoose.connection.db;
+
+    for (const [collectionName, indexes] of Object.entries(INDEX_SPECS)) {
+      const collection = db.collection(collectionName);
+
+      for (const { key, options } of indexes) {
+        try {
+          await collection.createIndex(key, options);
+          console.log(`[002] Created index '${options.name}' on '${collectionName}'`);
+        } catch (err) {
+          // Index already exists — safe to ignore
+          if (err.code === 85 || err.code === 86 || err.codeName === 'IndexAlreadyExists') {
+            console.log(`[002] Index '${options.name}' on '${collectionName}' already exists, skipping`);
+          } else {
+            throw err;
+          }
+        }
+      }
+    }
+
+    console.log('[002] Migration up complete');
+  },
+
+  down: async () => {
+    const db = mongoose.connection.db;
+
+    for (const [collectionName, indexes] of Object.entries(INDEX_SPECS)) {
+      const collection = db.collection(collectionName);
+
+      for (const { options } of indexes) {
+        try {
+          await collection.dropIndex(options.name);
+          console.log(`[002] Dropped index '${options.name}' on '${collectionName}'`);
+        } catch (err) {
+          if (err.code === 27) {
+            console.log(`[002] Index '${options.name}' on '${collectionName}' not found, skipping`);
+          } else {
+            throw err;
+          }
+        }
+      }
+    }
+
+    console.log('[002] Migration down complete');
+  },
+};

--- a/backend/src/models/ApiKey.js
+++ b/backend/src/models/ApiKey.js
@@ -43,6 +43,12 @@ apiKeySchema.statics.generateKey = function() {
   return crypto.randomBytes(32).toString('hex');
 };
 
+// Active keys by owner (auth middleware lookup)
+apiKeySchema.index({ owner: 1, status: 1 });
+
+// Expiry cleanup queries
+apiKeySchema.index({ expiresAt: 1 }, { sparse: true });
+
 const ApiKey = mongoose.model('ApiKey', apiKeySchema);
 
 module.exports = ApiKey;

--- a/backend/src/models/Credential.js
+++ b/backend/src/models/Credential.js
@@ -1,0 +1,75 @@
+const mongoose = require('mongoose');
+
+const credentialSchema = new mongoose.Schema({
+  id: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  issuer: {
+    type: String,
+    required: true,
+  },
+  subject: {
+    type: String,
+    required: true,
+  },
+  credentialType: {
+    type: String,
+    required: true,
+  },
+  claims: {
+    type: Map,
+    of: mongoose.Schema.Types.Mixed,
+  },
+  issued: {
+    type: Date,
+    required: true,
+    default: Date.now,
+  },
+  expires: {
+    type: Date,
+    default: null,
+  },
+  dataHash: {
+    type: String,
+  },
+  revoked: {
+    type: Boolean,
+    default: false,
+  },
+  credentialSchema: {
+    type: String,
+  },
+  proof: {
+    type: mongoose.Schema.Types.Mixed,
+  },
+}, { timestamps: true });
+
+// --- Indexes ---
+
+// Primary lookup by credential ID
+credentialSchema.index({ id: 1 }, { unique: true });
+
+// Most common query: credentials by issuer, filtered/sorted by issued date
+credentialSchema.index({ issuer: 1, issued: -1 });
+
+// Credentials by subject (holder lookup)
+credentialSchema.index({ subject: 1, issued: -1 });
+
+// Filter by type (analytics + search)
+credentialSchema.index({ credentialType: 1, issued: -1 });
+
+// Revocation status filter (frequently used in verification)
+credentialSchema.index({ revoked: 1, issued: -1 });
+
+// Expiry queries (find expired / active credentials)
+credentialSchema.index({ expires: 1 });
+
+// Compound: issuer + type (issuer analytics breakdown)
+credentialSchema.index({ issuer: 1, credentialType: 1, issued: -1 });
+
+// Compound: subject + revoked (subject's active credentials)
+credentialSchema.index({ subject: 1, revoked: 1 });
+
+module.exports = mongoose.model('Credential', credentialSchema);

--- a/backend/src/models/CredentialTemplate.js
+++ b/backend/src/models/CredentialTemplate.js
@@ -42,4 +42,10 @@ credentialTemplateSchema.pre('save', function(next) {
   next();
 });
 
+// Active templates by type (template lookup during issuance)
+credentialTemplateSchema.index({ credentialType: 1, active: 1 });
+
+// Issuer's templates
+credentialTemplateSchema.index({ issuerDid: 1, active: 1 });
+
 module.exports = mongoose.model('CredentialTemplate', credentialTemplateSchema);

--- a/backend/src/models/DID.js
+++ b/backend/src/models/DID.js
@@ -1,0 +1,55 @@
+const mongoose = require('mongoose');
+
+const didSchema = new mongoose.Schema({
+  did: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  owner: {
+    type: String,
+    required: true,
+  },
+  publicKey: {
+    type: String,
+  },
+  serviceEndpoint: {
+    type: String,
+  },
+  verificationMethods: {
+    type: [mongoose.Schema.Types.Mixed],
+    default: [],
+  },
+  services: {
+    type: [mongoose.Schema.Types.Mixed],
+    default: [],
+  },
+  active: {
+    type: Boolean,
+    default: true,
+  },
+  created: {
+    type: Date,
+    default: Date.now,
+  },
+  updated: {
+    type: Date,
+    default: Date.now,
+  },
+}, { timestamps: true });
+
+// --- Indexes ---
+
+// Primary lookup by DID string
+didSchema.index({ did: 1 }, { unique: true });
+
+// Owner's DIDs (most common list query)
+didSchema.index({ owner: 1, created: -1 });
+
+// Active DIDs by owner (filtered list)
+didSchema.index({ owner: 1, active: 1 });
+
+// Active status filter (global active DID queries)
+didSchema.index({ active: 1, created: -1 });
+
+module.exports = mongoose.model('DID', didSchema);

--- a/backend/src/models/Session.js
+++ b/backend/src/models/Session.js
@@ -32,4 +32,7 @@ const sessionSchema = new mongoose.Schema({
   }
 }, { timestamps: true });
 
+// Active sessions by user (auth validation)
+sessionSchema.index({ userId: 1, isValid: 1 });
+
 module.exports = mongoose.model('Session', sessionSchema);

--- a/backend/src/models/Webhook.js
+++ b/backend/src/models/Webhook.js
@@ -32,4 +32,10 @@ const webhookSchema = new mongoose.Schema({
   },
 });
 
+// Active webhooks lookup (most common query when dispatching events)
+webhookSchema.index({ active: 1 });
+
+// Filter by event type (dispatching specific events)
+webhookSchema.index({ events: 1, active: 1 });
+
 module.exports = mongoose.model('Webhook', webhookSchema);

--- a/backend/src/utils/queryAnalysis.js
+++ b/backend/src/utils/queryAnalysis.js
@@ -1,0 +1,123 @@
+const mongoose = require('mongoose');
+
+/**
+ * Runs explain() on a query and returns a summary of index usage and execution stats.
+ *
+ * @param {mongoose.Model} Model
+ * @param {object} filter  - MongoDB filter object
+ * @param {object} [sort]  - Sort spec, e.g. { issued: -1 }
+ * @returns {Promise<object>} Summary with indexUsed, docsExamined, docsReturned, executionTimeMs
+ */
+async function analyzeQuery(Model, filter, sort = {}) {
+  const query = Model.find(filter).sort(sort);
+  const plan = await query.explain('executionStats');
+
+  const stage = plan.executionStats;
+  const winningPlan = plan.queryPlanner.winningPlan;
+
+  // Walk the plan tree to find the index name (if any)
+  const indexName = extractIndexName(winningPlan);
+
+  return {
+    collection: Model.collection.collectionName,
+    filter,
+    sort,
+    indexUsed: indexName,
+    docsExamined: stage.totalDocsExamined,
+    keysExamined: stage.totalKeysExamined,
+    docsReturned: stage.nReturned,
+    executionTimeMs: stage.executionTimeMillis,
+    isCollectionScan: indexName === null,
+  };
+}
+
+/**
+ * Recursively walks a query plan stage tree to find the index name.
+ * Returns null if the plan is a COLLSCAN.
+ */
+function extractIndexName(stage) {
+  if (!stage) return null;
+  if (stage.stage === 'IXSCAN') return stage.indexName;
+  if (stage.stage === 'COLLSCAN') return null;
+  // Check inputStage or inputStages
+  if (stage.inputStage) return extractIndexName(stage.inputStage);
+  if (stage.inputStages) {
+    for (const s of stage.inputStages) {
+      const found = extractIndexName(s);
+      if (found !== null) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Lists all indexes on a collection with their sizes.
+ *
+ * @param {mongoose.Model} Model
+ * @returns {Promise<Array>}
+ */
+async function listIndexes(Model) {
+  const collection = mongoose.connection.db.collection(Model.collection.collectionName);
+  const indexes = await collection.indexes();
+  const stats = await collection.stats();
+  const indexSizes = stats.indexSizes || {};
+
+  return indexes.map(idx => ({
+    name: idx.name,
+    key: idx.key,
+    unique: idx.unique || false,
+    sparse: idx.sparse || false,
+    sizeBytes: indexSizes[idx.name] || null,
+  }));
+}
+
+/**
+ * Runs the standard set of queries for this application and reports
+ * which ones are missing index coverage (collection scans).
+ *
+ * @returns {Promise<Array>} Array of analysis results, collection scans flagged
+ */
+async function runIndexAudit() {
+  // Lazy-load models to avoid circular deps
+  const Credential = mongoose.model('Credential');
+  const DID = mongoose.model('DID');
+  const ApiKey = mongoose.model('ApiKey');
+  const Session = mongoose.model('Session');
+
+  const queries = [
+    { model: Credential, filter: { issuer: '__audit__' },                sort: { issued: -1 } },
+    { model: Credential, filter: { subject: '__audit__' },               sort: { issued: -1 } },
+    { model: Credential, filter: { credentialType: '__audit__' },        sort: { issued: -1 } },
+    { model: Credential, filter: { revoked: false },                     sort: { issued: -1 } },
+    { model: Credential, filter: { issuer: '__audit__', credentialType: '__audit__' }, sort: { issued: -1 } },
+    { model: Credential, filter: { subject: '__audit__', revoked: false }, sort: {} },
+    { model: DID,        filter: { owner: '__audit__' },                 sort: { created: -1 } },
+    { model: DID,        filter: { owner: '__audit__', active: true },   sort: {} },
+    { model: ApiKey,     filter: { owner: '__audit__', status: 'active' }, sort: {} },
+    { model: Session,    filter: { userId: '__audit__', isValid: true }, sort: {} },
+  ];
+
+  const results = [];
+  for (const { model, filter, sort } of queries) {
+    try {
+      const result = await analyzeQuery(model, filter, sort);
+      results.push(result);
+    } catch (err) {
+      results.push({ collection: model.collection.collectionName, filter, error: err.message });
+    }
+  }
+
+  const collectionScans = results.filter(r => r.isCollectionScan);
+  if (collectionScans.length > 0) {
+    console.warn('[queryAnalysis] Collection scans detected (missing indexes):');
+    collectionScans.forEach(r => {
+      console.warn(`  ${r.collection} filter=${JSON.stringify(r.filter)}`);
+    });
+  } else {
+    console.log('[queryAnalysis] All audited queries use indexes.');
+  }
+
+  return results;
+}
+
+module.exports = { analyzeQuery, listIndexes, runIndexAudit };


### PR DESCRIPTION
Closes #122 

- Add Credential and DID Mongoose models with compound indexes
- Add indexes to ApiKey, Session, Webhook, CredentialTemplate models
- Create migration 002_add_indexes.js to apply indexes to existing collections
- Add queryAnalysis utility for explain/audit of query performance

Indexes cover frequently queried fields: issuer, subject, credentialType, revoked, expires, owner, active, userId, status — following ESR rule for compound indexes to match query patterns in credentialService, didService, and analyticsService.